### PR TITLE
Request multiboot2

### DIFF
--- a/grub/grub.cfg
+++ b/grub/grub.cfg
@@ -1,3 +1,3 @@
 menuentry "os" {
-        multiboot /boot/os.bin
+        multiboot2 /boot/os.bin
 }

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -10,7 +10,8 @@ MKDIR_P ?= mkdir -p
 INCLUDE_FLAGS = -I./include -I../libc/include -I../libk/include
 CFLAGS = --target=i386-pc-none-elf -ffreestanding -O2 -std=c99 -Wall -Wextra $(INCLUDE_FLAGS)
 ASFLAGS = -felf32
-LDFLAGS = -nostdlib -L../libc/build/ -L../libk/build -lc -lk
+LDFLAGS = --target=i386-pc-none-elf -ffreestanding -nostdlib -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -mno-3dnow -Wl,-no-pie
+LINK_FLAGS = -L../libc/build/ -L../libk/build -lc -lk
 
 debug: CFLAGS += -g
 
@@ -27,7 +28,7 @@ all: build/os.bin
 debug: build/os.bin
 
 build/os.bin: $(OBJS_C) $(OBJS_ASM)
-	clang -T $(LINKER_PATH) $(CFLAGS) $^ -o $@ $(LDFLAGS)
+	clang $(LDFLAGS) -T $(LINKER_PATH) $^ -o $@ $(LINK_FLAGS)
 
 $(BUILD_DIR)/%.asm.o: $(SRC_ASM_DIR)/%.asm
 	$(MKDIR_P) $(dir $@)

--- a/kernel/src/asm/boot.asm
+++ b/kernel/src/asm/boot.asm
@@ -1,9 +1,8 @@
 ; Declare constants for the multiboot header.
-MBALIGN  equ  1 << 0            ; align loaded modules on page boundaries
-MEMINFO  equ  1 << 1            ; provide memory map
-MBFLAGS  equ  MBALIGN | MEMINFO ; this is the Multiboot 'flag' field
-MAGIC    equ  0x1BADB002        ; 'magic number' lets bootloader find the header
-CHECKSUM equ -(MAGIC + MBFLAGS)   ; checksum of above, to prove we are multiboot
+MAGIC    equ  0xE85250D6        ; 'magic number' lets bootloader find the header
+ARCHITECTURE equ 0              ; Specify i386 architecture
+LENGTH equ header_end - header  ; Length of the multiboot header
+CHECKSUM equ -(MAGIC + ARCHITECTURE + LENGTH)
 
 VMA_BASE equ 0xC0000000
 
@@ -22,11 +21,19 @@ VMA_PAGE_DIRECTORY_INDEX equ (VMA_BASE >> 22) ; VMA_BASE / 4MB = 768. This gives
 ; 32-bit boundary. The signature is in its own section so the header can be
 ; forced to be within the first 8 KiB of the kernel file.
 section .multiboot
-align 4
+header:
+align 8
 	dd MAGIC
-	dd MBFLAGS
+	dd ARCHITECTURE
+	dd LENGTH
 	dd CHECKSUM
- 
+
+	; end tag
+	dw 0
+	dw 0
+	dd 8
+header_end:
+
 ; The multiboot standard does not define the value of the stack pointer register
 ; (esp) and it is up to the kernel to provide a stack. This allocates room for a
 ; small stack by creating a symbol at the bottom of it, then allocating 16384

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,3 +1,3 @@
 
-cd .. && make $0
+cd .. && make
 

--- a/tools/iso.sh
+++ b/tools/iso.sh
@@ -1,8 +1,8 @@
-./build.sh $0
+./build.sh
 
 cd ..
 
-if grub-file --is-x86-multiboot ./kernel/build/os.bin; then
+if grub-file --is-x86-multiboot2 ./kernel/build/os.bin; then
   echo multiboot confirmed
 else
   echo the file is not multiboot


### PR DESCRIPTION
Use multiboot2. Grub's multiboot2 loader currently doesn't support relocs in ELF, so some linker flags had to be applied.