### PR TITLE
Add parsing of multiboot2 info

### DIFF
--- a/kernel/include/multiboot2.h
+++ b/kernel/include/multiboot2.h
@@ -1,0 +1,86 @@
+#ifndef OS_MULTIBOOT2_H
+#define OS_MULTIBOOT2_H
+
+#include <stdint.h>
+
+typedef struct {
+    uint8_t redPosition;
+    uint8_t redMaskSize; //size in bits of blue
+    uint8_t greenPosition;
+    uint8_t greenMaskSize; //size in bits of green
+    uint8_t bluePosition;
+    uint8_t blueMaskSize; //size in bits of blue
+} DirectColorInfo;
+
+typedef struct __attribute__((packed)) {
+    uint32_t magic;
+    uint32_t architecture;
+    uint32_t length;
+    uint32_t checksum;
+} MultibootHeader;
+
+typedef struct __attribute__((packed)) {
+    uint32_t size;
+    uint32_t reserved;
+} Multiboot2TagHeader;
+
+typedef struct __attribute__((packed)) {
+    uint32_t type;
+    uint32_t size;
+} Multiboot2Tag;
+
+typedef struct __attribute__((packed)) {
+    uint32_t type;
+    uint32_t size;
+    uint32_t lowerMemory;
+    uint32_t upperMemory;
+} MemInfo;
+
+typedef struct __attribute__((packed)) {
+    uint32_t type;
+    uint32_t size;
+    uint64_t framebuffer;
+    uint32_t pitch;
+    uint32_t width;
+    uint32_t height;
+    uint8_t bitsPerPixel;
+    uint8_t framebufferType;
+    uint16_t reserved;
+    DirectColorInfo colorInfo;
+} FramebufferInfo;
+
+typedef struct __attribute__((packed)) {
+    /**
+     * Memory available for use in kB
+     */
+    uint32_t memoryAvailable;
+    /**
+     * Whether we are in line graphics mode or character mode
+     */
+    uint8_t isGraphics;
+    /**
+     * Location of the framebuffer if isGraphics, NULL otherwise.
+     */
+    void* framebuffer;
+    /**
+     * Width of the screen. Pixels if isGraphics, characters otherwise
+     */
+    uint32_t width;
+    /**
+     * Height of the screen. Pixels if isGraphics, characters otherwise
+     */
+    uint32_t height;
+    /**
+     * Bits per pixel.
+     */
+    uint8_t bpp;
+    /**
+     * Pitch of the screen
+     */
+    uint32_t pitch;
+    DirectColorInfo colorInfo;
+} BootInfo;
+
+int parseBootInfo(BootInfo* bootInfo, void* address);
+
+#endif //OS_MULTIBOOT2_H

--- a/kernel/src/asm/boot.asm
+++ b/kernel/src/asm/boot.asm
@@ -115,6 +115,11 @@ _start:
     ; Set up the stack.
     mov esp, stack_top
 
+    ; Push pointer to multiboot structure
+    push ebx
+    ; Push magic number
+    push eax
+
     ; Enter the high-level kernel.
     extern kernel_main
     call kernel_main

--- a/kernel/src/c/kernel.c
+++ b/kernel/src/c/kernel.c
@@ -9,9 +9,14 @@
 #include "pmm.h"
 #include "serial.h"
 #include "mem.h"
+#include "multiboot2.h"
 
-__attribute__((unused)) void kernel_main(void) {
+__attribute__((unused)) void kernel_main(uint32_t magic, uint32_t rawAddress) {
+    uint32_t address = rawAddress + LOAD_MEMORY_ADDRESS;
     initializeTerminal();
+
+    BootInfo bootInfo;
+    parseBootInfo(&bootInfo, (void*)address);
 
     printf("Initializing COM1\n");
     Serial com1;

--- a/kernel/src/c/multiboot2/multiboot2.c
+++ b/kernel/src/c/multiboot2/multiboot2.c
@@ -1,0 +1,40 @@
+
+#include <stdio.h>
+#include "multiboot2.h"
+
+void* align(const void* address) {
+    return (void*)((uint32_t)((uint8_t*)address + 7) & ~7);
+}
+
+int parseBootInfo(BootInfo* bootInfo, void* address) {
+    Multiboot2TagHeader* header = (Multiboot2TagHeader*) address;
+
+    uint32_t totalSize = header->size;
+    printf("Total size is %d\n", totalSize);
+
+    for(Multiboot2Tag* tagAddress = (Multiboot2Tag*)((uint8_t*)address + sizeof(Multiboot2TagHeader));
+        (uint8_t*)tagAddress < (uint8_t*) address + totalSize;
+        tagAddress = align((uint8_t*)tagAddress + tagAddress->size)) {
+        printf("Got type: %d\n", tagAddress->type);
+
+        switch (tagAddress->type) {
+            case 4: {
+                MemInfo* memInfo = (MemInfo*) tagAddress;
+                bootInfo->memoryAvailable = memInfo->upperMemory;
+                break;
+            }
+            case 8: {
+                FramebufferInfo* framebufferInfo = (FramebufferInfo*) tagAddress;
+                bootInfo->isGraphics = 1;
+                bootInfo->framebuffer = (void*)framebufferInfo->framebuffer;
+                bootInfo->height = framebufferInfo->height;
+                bootInfo->width = framebufferInfo->width;
+                bootInfo->bpp = framebufferInfo->bitsPerPixel;
+                bootInfo->pitch = framebufferInfo->pitch;
+                break;
+            }
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Note that the multiboot2 specification is incorrect regarding size of reserved variable in the framebuffer info. It is actually a u16, not a u8 as the spec claims.