### PR TITLE
Fix/rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ GDB server: qemu-system-i386
 GDB server args: -s -S -cdrom <path to iso>
 ```
 
-Click the 'Debug' button in the Ide to
+Click the 'Debug' button in the IDE to
 start QEMU. Breakpoints and other debugging
 tools within CLion will work.
 

--- a/kernel/include/createbuffer.h
+++ b/kernel/include/createbuffer.h
@@ -5,7 +5,7 @@
 #include <buffer.h>
 
 /**
- * Allocate a file ideBuffer
+ * Allocate a file buffer
  * @param size size of the ideBuffer to allocate
  */
 FileBuffer* allocFileBuffer(int size);

--- a/kernel/include/createbuffer.h
+++ b/kernel/include/createbuffer.h
@@ -6,7 +6,7 @@
 
 /**
  * Allocate a file buffer
- * @param size size of the ideBuffer to allocate
+ * @param size size of the buffer to allocate
  */
 FileBuffer* allocFileBuffer(int size);
 

--- a/libk/include/buffer.h
+++ b/libk/include/buffer.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-// must be kept up to date with kernel's ideBuffer.h
+// must be kept up to date with kernel's buffer.h
 typedef struct {
     int readHead;
     int writeHead;
@@ -24,7 +24,7 @@ int bufferAvailable(FileBuffer* buffer);
 int bufferRemaining(FileBuffer* buffer);
 
 /**
- * Write a byte to the ideBuffer
+ * Write a byte to the buffer
  * @param buffer
  * @param byte
  * @return whether the data was successfully written
@@ -32,7 +32,7 @@ int bufferRemaining(FileBuffer* buffer);
 int writeByte(FileBuffer* buffer, uint8_t byte);
 
 /**
- * Read a byte from the ideBuffer
+ * Read a byte from the buffer
  * @param buffer
  * @param result the byte read
  * @return
@@ -40,7 +40,7 @@ int writeByte(FileBuffer* buffer, uint8_t byte);
 int readByte(FileBuffer* buffer, uint8_t* result);
 
 /**
- * Write a character to the ideBuffer
+ * Write a character to the buffer
  * @param buffer
  * @param c
  * @return whether the character was successfully written


### PR DESCRIPTION
Fix incorrect project-wide renames. Sometimes CLion incorrectly matches a different symbol with the same name.