### PR TITLE
Fix iso build on CI

### DIFF
--- a/.github/workflows/iso.yaml
+++ b/.github/workflows/iso.yaml
@@ -1,3 +1,4 @@
+name: iso
 on:
   push:
     branches:

--- a/.github/workflows/iso.yaml
+++ b/.github/workflows/iso.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Build iso
-        run:  cd tools && ./iso.sh
+        run:  cd tools && ./build.sh && ./iso.sh
       - name: Upload iso
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/iso.yaml
+++ b/.github/workflows/iso.yaml
@@ -8,6 +8,7 @@ jobs:
     name: Build iso
     runs-on: ubuntu-latest
     steps:
+      - uses: ilammy/setup-nasm@v1
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Build iso

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,7 @@ jobs:
     name: Build and Run Tests
     runs-on: ubuntu-latest
     steps:
+      - uses: ilammy/setup-nasm@v1
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Build and Run Tests

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,4 +1,3 @@
 
 mkdir ../cmake-build-debug
-cd ../cmake-build-debug && cmake .. && cmake --build .
-
+cd ../cmake-build-debug && cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .. && cmake --build .


### PR DESCRIPTION
Turns out that I made two mistakes:

1. GitHub actions does not include nasm by default
2. The build.sh script must be called before iso.sh