### PR TITLE
Add handling for different video modes

### DIFF
--- a/grub/grub.cfg
+++ b/grub/grub.cfg
@@ -1,3 +1,20 @@
+function load_video {
+    if [ x$feature_all_video_module = xy ]; then
+        insmod all_video
+    else
+        insmod efi_gop
+        insmod efi_uga
+        insmod ieee1275_fb
+        insmod vbe
+        insmod vga
+        insmod video_bochs
+        insmod video_cirrus
+    fi
+}
+
+insmod ext2
+
 menuentry "os" {
-        multiboot2 /boot/os.bin
+    load_video
+    multiboot2 /boot/os.bin
 }

--- a/kernel/src/c/graphics/canvas.c
+++ b/kernel/src/c/graphics/canvas.c
@@ -18,7 +18,7 @@ void initializeCanvas(Canvas* canvas, uint32_t w, uint32_t h, uint32_t pitch,
 void drawRect(Canvas* canvas, int x, int y, int w, int h, RgbColor color) {
     for(int row = y; row < y+h; row++) {
         for(int col = x; col < x+w; col++) {
-            int index = 4*col + row*canvas->pitch;
+            uint32_t index = canvas->bpp/8*col + row*canvas->pitch;
             canvas->buffer[index+2] = color.r;
             canvas->buffer[index+1] = color.g;
             canvas->buffer[index] = color.b;
@@ -33,6 +33,7 @@ void drawCharacter(Canvas* canvas, char c, int x, int y) {
     uint32_t fontHeight = canvas->fontHeight;
     PsfFont font = defaultFont; //Todo: store font in canvas
     PsfCharacter character = font.characterTable[c-32];
+    int bytesPerPixel = canvas->bpp/8;
 
     for(uint32_t drawY = 0; drawY < fontHeight; drawY++) {
         for(uint32_t drawX = 0; drawX < fontWidth; drawX++) {
@@ -46,7 +47,7 @@ void drawCharacter(Canvas* canvas, char c, int x, int y) {
 
             uint8_t isColored = character.bitmap[fontY] & (1 << (7-fontX));
             if(isColored) {
-                int index = 4*(drawX + x) + (drawY + y)*canvas->pitch;
+                int index = bytesPerPixel*(drawX + x) + (drawY + y)*canvas->pitch;
                 RgbColor color = canvas->textColor;
                 canvas->buffer[index+2] = color.r;
                 canvas->buffer[index+1] = color.g;


### PR DESCRIPTION
The canvas originally assumed a pixel stride of 32 bit. This PR supports RGB with any stride, as long as the R, G, and B are each 8 bit and packed. A future PR should check the start and size of the RGB values.