### PR TITLE
Add RSDP reading and validation

### DIFF
--- a/kernel/include/multiboot2.h
+++ b/kernel/include/multiboot2.h
@@ -54,12 +54,7 @@ typedef struct __attribute__((packed)) {
     uint32_t type;
     uint32_t size;
     RSDP rsdp;
-} AcpiOldRSDP;
-
-typedef struct __attribute__((packed)) {
-    uint32_t type;
-    uint32_t rsdpv2;
-} AcpiNewRSDP;
+} Acpi1RSDP;
 
 typedef struct __attribute__((packed)) {
     /**

--- a/kernel/include/multiboot2.h
+++ b/kernel/include/multiboot2.h
@@ -2,6 +2,7 @@
 #define OS_MULTIBOOT2_H
 
 #include <stdint.h>
+#include "rsdp.h"
 
 typedef struct {
     uint8_t redPosition;
@@ -50,6 +51,17 @@ typedef struct __attribute__((packed)) {
 } FramebufferInfo;
 
 typedef struct __attribute__((packed)) {
+    uint32_t type;
+    uint32_t size;
+    RSDP rsdp;
+} AcpiOldRSDP;
+
+typedef struct __attribute__((packed)) {
+    uint32_t type;
+    uint32_t rsdpv2;
+} AcpiNewRSDP;
+
+typedef struct __attribute__((packed)) {
     /**
      * Memory available for use in kB
      */
@@ -79,6 +91,8 @@ typedef struct __attribute__((packed)) {
      */
     uint32_t pitch;
     DirectColorInfo colorInfo;
+
+    RSDP rsdp;
 } BootInfo;
 
 int parseBootInfo(BootInfo* bootInfo, void* address);

--- a/kernel/include/rsdp.h
+++ b/kernel/include/rsdp.h
@@ -1,0 +1,17 @@
+#ifndef OS_ACPI_H
+#define OS_ACPI_H
+
+#include <stdint.h>
+
+typedef struct __attribute__ ((packed)) {
+    char signature[8];
+    uint8_t checksum;
+    char oemid[6];
+    uint8_t revision;
+    uint32_t rsdtAddress;
+} RSDP;
+
+int validateRSDP(RSDP* rsdp);
+int getAcpiVersion(RSDP* rsdp);
+
+#endif //OS_ACPI_H

--- a/kernel/kernel.cmake
+++ b/kernel/kernel.cmake
@@ -21,8 +21,9 @@ include(GoogleTest)
 file(GLOB_RECURSE SERIAL_SOURCES ${CMAKE_SOURCE_DIR}/kernel/src/c/serial/**.c)
 file(GLOB_RECURSE IDT_SOURCES ${CMAKE_SOURCE_DIR}/kernel/src/c/idt/**.c)
 file(GLOB_RECURSE CPUID_SOURCES ${CMAKE_SOURCE_DIR}/kernel/src/c/cpuid/**.c)
+file(GLOB_RECURSE ACPI_SOURCES ${CMAKE_SOURCE_DIR}/kernel/src/c/acpi/**.c)
 
-add_executable(kernel_test ${KERNEL_TEST_SOURCES} ${SERIAL_SOURCES} ${IDT_SOURCES} ${CPUID_SOURCES})
+add_executable(kernel_test ${KERNEL_TEST_SOURCES} ${SERIAL_SOURCES} ${IDT_SOURCES} ${CPUID_SOURCES} ${ACPI_SOURCES})
 target_link_libraries(kernel_test GTest::gtest)
 
 target_compile_definitions(kernel_test PRIVATE TESTING)

--- a/kernel/src/c/acpi/rsdp.c
+++ b/kernel/src/c/acpi/rsdp.c
@@ -1,0 +1,31 @@
+#include "rsdp.h"
+
+int getAcpiVersion(RSDP* rsdp) {
+    if(rsdp->revision == 0 || rsdp->revision == 1) return 1;
+    else if(rsdp->revision == 2) return 2;
+    else return -1;
+}
+
+int validateRSDP(RSDP* rsdp) {
+    int signatureCheck =
+            rsdp->signature[0] == 'R' &&
+            rsdp->signature[1] == 'S' &&
+            rsdp->signature[2] == 'D' &&
+            rsdp->signature[3] == ' ' &&
+            rsdp->signature[4] == 'P' &&
+            rsdp->signature[5] == 'T' &&
+            rsdp->signature[6] == 'R' &&
+            rsdp->signature[7] == ' ';
+
+    int versionCheck = rsdp->revision == 0 || rsdp->revision == 2;
+
+    uint8_t checksum = 0;
+
+    uint8_t* rsdpBytes = (uint8_t*) rsdp;
+
+    for(int i = 0; i < sizeof(RSDP); i++) {
+        checksum += rsdpBytes[i];
+    }
+
+    return checksum == 0 && versionCheck && signatureCheck;
+}

--- a/kernel/src/c/kernel.c
+++ b/kernel/src/c/kernel.c
@@ -18,6 +18,7 @@
 #include "ext2.h"
 #include "vfs.h"
 #include "cpuid.h"
+#include "rsdp.h"
 
 __attribute__((unused)) void kernel_main(uint32_t magic, uint32_t rawAddress) {
     uint32_t address = rawAddress + LOAD_MEMORY_ADDRESS;
@@ -54,6 +55,10 @@ __attribute__((unused)) void kernel_main(uint32_t magic, uint32_t rawAddress) {
     initializeBuffers(in, out);
 
     registerInterruptHandler(0x20 + 1, handleKeyboard);
+
+    int isValidRsdp = validateRSDP(&bootInfo.rsdp);
+
+    printf("Is RSDP valid? %d\n", isValidRsdp);
 
     PciBus* pciBus = malloc(sizeof(PciBus));
 

--- a/kernel/src/c/multiboot2/multiboot2.c
+++ b/kernel/src/c/multiboot2/multiboot2.c
@@ -31,7 +31,7 @@ int parseBootInfo(BootInfo* bootInfo, void* address) {
                 break;
             }
             case 14: {
-                AcpiOldRSDP* acpiInfo = (AcpiOldRSDP*) tagAddress;
+                Acpi1RSDP* acpiInfo = (Acpi1RSDP*) tagAddress;
                 bootInfo->rsdp = acpiInfo->rsdp;
             }
         }

--- a/kernel/src/c/multiboot2/multiboot2.c
+++ b/kernel/src/c/multiboot2/multiboot2.c
@@ -30,6 +30,10 @@ int parseBootInfo(BootInfo* bootInfo, void* address) {
                 bootInfo->pitch = framebufferInfo->pitch;
                 break;
             }
+            case 14: {
+                AcpiOldRSDP* acpiInfo = (AcpiOldRSDP*) tagAddress;
+                bootInfo->rsdp = acpiInfo->rsdp;
+            }
         }
     }
 

--- a/kernel/test/src/rsdp.cpp
+++ b/kernel/test/src/rsdp.cpp
@@ -1,0 +1,65 @@
+#include "gtest/gtest.h"
+
+extern "C" {
+#include "rsdp.h"
+}
+
+TEST(RSDPTest, CheckValidRSDP) {
+    char* signatureText = "RSD PTR ";
+    char* oem = "Test   ";
+    RSDP validRsdp = {
+            .checksum = 101,
+            .revision = 0,
+            .rsdtAddress = 0x123456
+    };
+
+    memcpy(validRsdp.signature, signatureText, 8);
+    memcpy(validRsdp.oemid, oem, 6);
+
+    ASSERT_TRUE(validateRSDP(&validRsdp));
+}
+
+TEST(RSDPTest, CheckIncorrectSignature) {
+    char* signatureText = "Wrong Si";
+    char* oem = "Test   ";
+    RSDP validRsdp = {
+            .checksum = 155,
+            .revision = 0,
+            .rsdtAddress = 0x123456
+    };
+
+    memcpy(validRsdp.signature, signatureText, 8);
+    memcpy(validRsdp.oemid, oem, 6);
+
+    ASSERT_FALSE(validateRSDP(&validRsdp));
+}
+
+TEST(RSDPTest, CheckIncorrectRevision) {
+    char* signatureText = "RSD PTR ";
+    char* oem = "Test   ";
+    RSDP validRsdp = {
+            .checksum = 97,
+            .revision = 4,
+            .rsdtAddress = 0x123456
+    };
+
+    memcpy(validRsdp.signature, signatureText, 8);
+    memcpy(validRsdp.oemid, oem, 6);
+
+    ASSERT_FALSE(validateRSDP(&validRsdp));
+}
+
+TEST(RSDPTest, CheckIncorrectChecksum) {
+    char* signatureText = "RSD PTR ";
+    char* oem = "Test   ";
+    RSDP validRsdp = {
+            .checksum = 123,
+            .revision = 0,
+            .rsdtAddress = 0x123456
+    };
+
+    memcpy(validRsdp.signature, signatureText, 8);
+    memcpy(validRsdp.oemid, oem, 6);
+
+    ASSERT_FALSE(validateRSDP(&validRsdp));
+}


### PR DESCRIPTION
The Root System Description pointer is needed in order to enable ACPI. This PR adds the ability to find it. The initial plan is to only support ACPI 1, so the extended fields added in ACPI 2.0 are ignored.