### PR TITLE
Ignore linter for files copied from third-party source

### DIFF
--- a/kernel/src/c/mem/bucket/bucket.h
+++ b/kernel/src/c/mem/bucket/bucket.h
@@ -21,6 +21,8 @@
  *
  */
 
+// NOLINTBEGIN
+
 #ifndef BUCKET_H
 #define BUCKET_H
 
@@ -126,3 +128,5 @@ void *realloc(void *ptr, size_t size); // The standard function.
 void mfree(void *ptr);   // The standard function.
 
 #endif   // BUCKET_H
+
+// NOLINTEND

--- a/kernel/src/c/mem/bucket/malloc.c
+++ b/kernel/src/c/mem/bucket/malloc.c
@@ -22,9 +22,13 @@
  *
  */
 
+// NOLINTBEGIN
+
 /*
  * Modified for use with this OS. Main modifications include removing spinlock (this is
  * a single-threaded OS currently) and changing ctypes (this OS uses stdint).
+ *
+ * I also added the NOLINT comments for the linter
  */
 
 #include <string.h>
@@ -406,3 +410,5 @@ void mfree(void *ptr) {
     else
         bucket_update_largest(bucket);
 }
+
+// NOLINTEND


### PR DESCRIPTION
I'd rather minimize changes to make updating easier.