### PR TITLE
Handle any failure while running tests

### DIFF
--- a/tools/runtests.sh
+++ b/tools/runtests.sh
@@ -3,8 +3,8 @@
 mkdir ../build-tests
 cd ../build-tests
 
-cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .. && cmake --build .
+cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ .. && cmake --build . && \
 
-./kernel_test --gtest_output=xml:report/report-kernel.xml
-./libc_test --gtest_output=xml:report/report-libc.xml
+./kernel_test --gtest_output=xml:report/report-kernel.xml && \
+./libc_test --gtest_output=xml:report/report-libc.xml && \
 ./libk_test --gtest_output=xml:report/report-libk.xml


### PR DESCRIPTION
Previously, the test script would hide failures other than the last test run